### PR TITLE
ghtable includes wy-10-01 now (was an issue w/ timezones)

### DIFF
--- a/R/workflow-functions.R
+++ b/R/workflow-functions.R
@@ -71,3 +71,9 @@ formatDate <- function(date){
          day(date), ", ",
          year(date))
 }
+
+convertWYtoDate <- function(wy){
+  s <- as.POSIXct(paste0(wy-1, "-10-01"), tz = "UTC")
+  e <- as.POSIXct(paste0(wy, "-09-30"), tz = "UTC")
+  return(list(wy_start = s, wy_end = e))
+}

--- a/Report_templates/depthprofiles.Rmd
+++ b/Report_templates/depthprofiles.Rmd
@@ -12,8 +12,9 @@ source("../R/functions-depthprofiles.R")
 ```
 
 ```{r echo=FALSE, warning=FALSE, message=FALSE}
-wy_start <- as.POSIXct(paste0(wy-1, "-10-01"))
-wy_end <- as.POSIXct(paste0(wy, "-09-30"))
+wy_dates <- convertWYtoDate(wy)
+wy_start <- wy_dates$wy_start
+wy_end <- wy_dates$wy_end
 
 # pull in ranges from csv file & filter for just this site
 column_classes <- c(rep("character", 2), rep("numeric", 8))

--- a/Report_templates/ghtable.Rmd
+++ b/Report_templates/ghtable.Rmd
@@ -12,8 +12,9 @@ source("../R/functions-ghtable.R")
 ```
 
 ```{r echo=FALSE, warning=FALSE, message=FALSE}
-wy_start <- as.POSIXct(paste0(wy-1, "-10-01"))
-wy_end <- as.POSIXct(paste0(wy, "-09-30"))
+wy_dates <- convertWYtoDate(wy)
+wy_start <- wy_dates$wy_start
+wy_end <- wy_dates$wy_end
 
 stage_data <- readNWISdata(service = "dv", sites = siteNumber, 
                            parameterCd = "00065", startDate = "1800-01-01", 

--- a/Report_templates/qwtable.Rmd
+++ b/Report_templates/qwtable.Rmd
@@ -11,8 +11,9 @@ source("../R/functions-qwtable.R")
 ```
 
 ```{r echo=FALSE, warning=FALSE, message=FALSE, comment=NA}
-wy_start <- as.POSIXct(paste0(wy-1, "-10-01"))
-wy_end <- as.POSIXct(paste0(wy, "-09-30"))
+wy_dates <- convertWYtoDate(wy)
+wy_start <- wy_dates$wy_start
+wy_end <- wy_dates$wy_end
 
 pcodes <- read.csv("../data/pcodes.lakes1",header=FALSE,
                    colClasses = "character")[,1]

--- a/Report_templates/qwtimeseries.Rmd
+++ b/Report_templates/qwtimeseries.Rmd
@@ -9,7 +9,8 @@ source("../R/functions-qwtimeseries.R")
 ```
 
 ```{r echo=FALSE, warning=FALSE, message=FALSE, fig.height = 14, fig.width=11} 
-wy_end <- as.POSIXct(paste0(wy, "-09-30"))
+wy_dates <- convertWYtoDate(wy)
+wy_end <- wy_dates$wy_end
 
 pcodes <- c("00665", "00666", "32210", "00078")
 

--- a/Report_templates/stagehydrograph.Rmd
+++ b/Report_templates/stagehydrograph.Rmd
@@ -12,8 +12,9 @@ source("../R/functions-stagehydrograph.R")
 ```
 
 ```{r echo=FALSE, warning=FALSE, message=FALSE}
-wy_start <- as.POSIXct(paste0(wy-1, "-10-01"))
-wy_end <- as.POSIXct(paste0(wy, "-09-30"))
+wy_dates <- convertWYtoDate(wy)
+wy_start <- wy_dates$wy_start
+wy_end <- wy_dates$wy_end
 
 extraInfo <- list(...)
 


### PR DESCRIPTION
- Fix for #14 (timezone issue - nwis data was UTC and our times defaulted to CDT, so 10-01 UTC was not greater than or equal to 10-01 CDT and was filtered out)
- function created to convert the provided water year to the actual start and end dates