### PR TITLE
Moved stage hydrograph title to accommodate several decimal places

### DIFF
--- a/R/functions-stagehydrograph.R
+++ b/R/functions-stagehydrograph.R
@@ -27,7 +27,7 @@ makeStageHydrograph_dataRetrieval <- function(stage_data){
     axis(side=1, at=allDates, labels=allYears) %>% 
     axis(side=3, at=allDates, labels=FALSE) %>%
     axis(side=2, n.minor=4) %>%
-    title(ylab = "GAGE HEIGHT, IN FEET")
+    title(ylab = "GAGE HEIGHT, IN FEET", line=2)
   
   return(stageHydrograph)
 }

--- a/R/functions-stagehydrograph.R
+++ b/R/functions-stagehydrograph.R
@@ -27,7 +27,7 @@ makeStageHydrograph_dataRetrieval <- function(stage_data){
     axis(side=1, at=allDates, labels=allYears) %>% 
     axis(side=3, at=allDates, labels=FALSE) %>%
     axis(side=2, n.minor=4) %>%
-    title(ylab = "GAGE HEIGHT, IN FEET", line=3)
+    title(ylab = "GAGE HEIGHT, IN FEET")
   
   return(stageHydrograph)
 }
@@ -57,7 +57,7 @@ makeStageHydrograph_file <- function(stage_data, siteNumber, startDate){
     axis(side=1, at=allDates, labels=allYears) %>% 
     axis(side=3, at=allDates, labels=FALSE) %>%
     axis(side=2, n.minor=4) %>%
-    title(ylab = "GAGE HEIGHT, IN FEET")
+    title(ylab = "GAGE HEIGHT, IN FEET", line=2)
   
   return(stageHydrograph)
 }


### PR DESCRIPTION
For plots with several decimal places on the y-axis, there won't be anymore overlap.  This addresses part of the #67, but not all, as I'm still working on adjustments to the qwtimeseries labels.