### PR TITLE
actually print the error

### DIFF
--- a/R/workflow-functions.R
+++ b/R/workflow-functions.R
@@ -25,7 +25,8 @@ makeReports <- function(siteNumber, wy, plotNames, output, ...){
       #generate a report for the current plotName (p) and siteNumber (s)
       status_report <- tryCatch(renderLakeReport(p, s, wy, output, ...), 
                                 error = function(e){
-                                  return(as.character(e))
+                                  err_msg <- gsub("\n", "", e)
+                                  return(err_msg)
                                 })
       if(grepl("Error", status_report)){
         failed_reports <- rbind(failed_reports, 

--- a/R/workflow-functions.R
+++ b/R/workflow-functions.R
@@ -24,9 +24,12 @@ makeReports <- function(siteNumber, wy, plotNames, output, ...){
     for(p in plotNames_specified){
       #generate a report for the current plotName (p) and siteNumber (s)
       status_report <- tryCatch(renderLakeReport(p, s, wy, output, ...), 
-                                error = function(e){"FAILED"})
-      if(status_report == "FAILED"){
-        failed_reports <- rbind(failed_reports, data.frame(siteNumber = s, plotName = p))
+                                error = function(e){
+                                  return(as.character(e))
+                                })
+      if(grepl("Error", status_report)){
+        failed_reports <- rbind(failed_reports, 
+                                data.frame(siteNumber = s, plotName = p, error = status_report))
       } else {
         successful_count <- successful_count + 1
       }


### PR DESCRIPTION
Actually shows you the error now rather than it being a mystery.

Failure:
```
Quitting from lines 9-14 (qwtable.Rmd) 



 0 reports successful

FAILED REPORTS:
       siteNumber plotName                                                       error
1 455638089034501  qwtable Error in library(tidyr): there is no package called 'tidyr'
```

Success:
```
Output created: 2014/qwtable_2014_455638089034501.word


 1 reports successful

FAILED REPORTS:
data frame with 0 columns and 0 rows
```