### PR TITLE
Labels, main title, sub title appearing in the right spot for depth profiles

### DIFF
--- a/Report_templates/depthprofiles.Rmd
+++ b/Report_templates/depthprofiles.Rmd
@@ -163,7 +163,8 @@ if(length(dts) > 0){
     ylabel_line <- 2
   }
   
-  gs.dummy <- gsplot(mar = c(5,2.6,4.5,0.6)) # needed to have layouts work, see gsplot github issue #404
+  gs.setup.bottom <- gsplot(mar = c(4,2.6,5.5,0.6)) # needed to have layouts work, see gsplot github issue #404
+  gs.setup.top <- gsplot(mar = c(2,2.6,7.5,0.6))
   plot_setup <- matrix(1:(2*num_plots_on_page), 2, num_plots_on_page)
   layout(plot_setup)
 
@@ -174,11 +175,11 @@ if(length(dts) > 0){
   
   for(t in seq_along(dts)){
     left_logic <- t == 1 #is it the farthest left plot
-    print(depthProfilePlot(gs.dummy, 
+    print(depthProfilePlot(gs.setup.top, 
                            side1 = h2otemp, side3 = DO, 
                            filter_date = dts[t], top = TRUE, 
                            left=left_logic, xranges=plotRanges))
-    print(depthProfilePlot(gs.dummy, 
+    print(depthProfilePlot(gs.setup.bottom, 
                            side1 = specifcond, side3 = PH, 
                            filter_date = dts[t], top = FALSE, 
                            left = left_logic, xranges = plotRanges))
@@ -191,19 +192,26 @@ if(length(dts) > 0){
 
   #add titles around the plot
   title(ylab = "DEPTH, IN METERS",
-        outer = TRUE, line = ylabel_line)
-  title(xlab = specifcond_title,
-        outer = TRUE, line = 2)
-  title(xlab = PH_title,
-        outer = TRUE, line = -24)
-  title(xlab = h2otemp_title,
-        outer = TRUE, line = -27.5)
-  title(xlab = DO_title,
-        outer = TRUE, line = -47.8)
-  title(xlab = plot_sub_title, 
-          outer = TRUE, line = -49)
+          outer = TRUE, 
+          line = -1)
+    title(xlab = specifcond_title,
+          outer = TRUE, 
+          line = -2)
+    title(xlab = PH_title,
+          outer = TRUE, 
+          line = -22)
+    title(xlab = h2otemp_title,
+          outer = TRUE, 
+          line = -24.5)
+    title(xlab = DO_title,
+          outer = TRUE, 
+          line = -44.8)
+    title(xlab = plot_sub_title, 
+          outer = TRUE, 
+          line = -48)
     title(main = plot_main_title, 
-          outer = TRUE, line = -55)
+          outer = TRUE,
+          line = -1)
 
 }
 


### PR DESCRIPTION
...that don't have 5 dates/year.

This relates to issue #74.

The only thing not working quite right is that for less than 5 plots, they aren't centered.

@lindsaycarr 